### PR TITLE
Expo SDK 33 - Change the dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ import reducers from "./reducers";
 // Secure storage
 const storage = createSecureStore();
 const config = {
-    key: "root",
-    storage
+  key: "root",
+  storage
 };
 
 const reducer = persistCombineReducers(config, reducers);
 
-function configureStore () {
+function configureStore() {
   // ...
   let store = createStore(reducer);
   let persistor = persistStore(store);
@@ -50,7 +50,7 @@ import createSecureStore from "redux-persist-expo-securestore";
 
 import { combineReducers } from "redux";
 import { persistReducer } from "redux-persist";
-import AsyncStorage from 'redux-persist/lib/storage';
+import AsyncStorage from "redux-persist/lib/storage";
 
 import { mainReducer, secureReducer } from "./reducers";
 
@@ -73,7 +73,7 @@ const rootReducer = combineReducers({
   secure: persistReducer(securePersistConfig, secureReducer)
 });
 
-function configureStore () {
+function configureStore() {
   // ...
   let store = createStore(rootReducer);
   let persistor = persistStore(store);
@@ -88,7 +88,7 @@ function configureStore () {
 
 #### `[options]`: `object`
 
-Options to pass to [Expo's SecureStore](https://docs.expo.io/versions/latest/sdk/securestore.html):
+Options to pass to [Expo's SecureStore](https://docs.expo.io/versions/latest/sdk/securestore/):
 
 ##### `keychainService`: `string`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-persist-expo-securestore",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "redux-persist storage for Expo's SecureStore",
   "main": "src/index.js",
   "types": "src/index.d.ts",
@@ -9,6 +9,6 @@
   "license": "MIT",
   "private": false,
   "peerDependencies": {
-    "expo": ">=20"
+    "expo-secure-store": "^5.0.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { SecureStore } from "expo";
+import * as SecureStore from 'expo-secure-store';
 
 export default function createSecureStorage(options = {}) {
 	const replaceCharacter = options.replaceCharacter || "_";


### PR DESCRIPTION
Hi @Cretezy,

The new expo SDK 33 is released. 
I would like to do several changes on your package which don't need anymore the entire expo dependency. 
https://docs.expo.io/versions/latest/sdk/securestore/

What do you think about it ? 
Maybe it will be a major release.
