### PR TITLE
Bump `expo-secure-store` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write 'src/**/*.{js,ts}' package.json README.md"
   },
   "peerDependencies": {
-    "expo-secure-store": "^5.0.1"
+    "expo-secure-store": "^12.5.0"
   },
   "devDependencies": {
     "prettier": "^1.18.2"


### PR DESCRIPTION
This is done in order to fix the `@unimodules/core` dependency issue in new Expo version.